### PR TITLE
show examples of missing files

### DIFF
--- a/sciencebeam_utils/tools/check_file_list.py
+++ b/sciencebeam_utils/tools/check_file_list.py
@@ -48,23 +48,32 @@ def map_file_list_to_file_exists(file_list):
         return list(executor.map(FileSystems.exists, file_list))
 
 
-def format_file_exists_results(file_exists):
+def format_file_list(file_list):
+    return '%s' % file_list
+
+
+def format_file_exists_results(file_exists, file_list):
     if not file_exists:
         return 'empty file list'
     file_exists_count = sum(file_exists)
     file_missing_count = len(file_exists) - file_exists_count
+    files_missing = [s for s, exists in zip(file_list, file_exists) if not exists]
     return (
-        'files exist: %d (%.0f%%), files missing: %d (%.0f%%)' %
-        (
+        'files exist: %d (%.0f%%), files missing: %d (%.0f%%)%s' % (
             file_exists_count, 100.0 * file_exists_count / len(file_exists),
-            file_missing_count, 100.0 * file_missing_count / len(file_exists)
+            file_missing_count, 100.0 * file_missing_count / len(file_exists),
+            (
+                ' (example missing: %s)' % format_file_list(files_missing[:3])
+                if files_missing
+                else ''
+            )
         )
     )
 
 
 def check_files_and_report_result(file_list):
     file_exists = map_file_list_to_file_exists(file_list)
-    LOGGER.info('%s', format_file_exists_results(file_exists))
+    LOGGER.info('%s', format_file_exists_results(file_exists, file_list))
     assert sum(file_exists) > 0
 
 

--- a/sciencebeam_utils/tools/check_file_list_test.py
+++ b/sciencebeam_utils/tools/check_file_list_test.py
@@ -5,6 +5,7 @@ import pytest
 import sciencebeam_utils.tools.check_file_list as check_file_list_module
 from sciencebeam_utils.tools.check_file_list import (
     map_file_list_to_file_exists,
+    format_file_list,
     format_file_exists_results,
     check_files_and_report_result
 )
@@ -24,23 +25,33 @@ class TestMapFileListToFileExists(object):
             FileSystems.exists.assert_called_with(FILE_1)
 
 
+class TestFormatFileList(object):
+    def test_should_format_multiple_files(self):
+        assert (
+            format_file_list([FILE_1, FILE_2]) ==
+            "['%s', '%s']" % (FILE_1, FILE_2)
+        )
+
+
 class TestFormatFileExistsResults(object):
     def test_should_format_no_files(self):
         assert (
-            format_file_exists_results([]) ==
+            format_file_exists_results([], []) ==
             'empty file list'
         )
 
     def test_should_format_all_files_exist(self):
         assert (
-            format_file_exists_results([True, True]) ==
+            format_file_exists_results([True, True], [FILE_1, FILE_2]) ==
             'files exist: 2 (100%), files missing: 0 (0%)'
         )
 
     def test_should_format_files_partially_exist(self):
         assert (
-            format_file_exists_results([True, False]) ==
-            'files exist: 1 (50%), files missing: 1 (50%)'
+            format_file_exists_results([True, False], [FILE_1, FILE_2]) ==
+            'files exist: 1 (50%), files missing: 1 (50%) (example missing: {})'.format(
+                format_file_list([FILE_2])
+            )
         )
 
 
@@ -52,7 +63,7 @@ class TestCheckFileListAndReportResults(object):
                 map_file_list_to_file_exists_mock.return_value = [True, True]
                 check_files_and_report_result([FILE_1, FILE_2])
                 map_file_list_to_file_exists_mock.assert_called_with([FILE_1, FILE_2])
-                format_file_exists_results_mock.assert_called_with([True, True])
+                format_file_exists_results_mock.assert_called_with([True, True], [FILE_1, FILE_2])
 
     def test_should_raise_error_if_none_of_the_files_were_found(self):
         m = check_file_list_module


### PR DESCRIPTION
Context: The check file list command checks whether the files in the file list exist. This is often used when generating output file lists to check that the file urls are correct. Some files may be missing (e.g. due to conversion errors).

This change makes it a bit easier to see which files are missing.