### PR TITLE
added support for extend a dataset split

### DIFF
--- a/sciencebeam_utils/tools/split_csv_dataset.py
+++ b/sciencebeam_utils/tools/split_csv_dataset.py
@@ -77,7 +77,7 @@ def _to_hashable(value):
     return tuple(value)
 
 
-def _to_rows_set(rows):
+def _to_row_set(rows):
     return {_to_hashable(row) for row in rows}
 
 
@@ -99,8 +99,8 @@ def split_rows(
     if not existing_split:
         return _split_rows_without_existing_split(rows, percentages, fill=fill)
     LOGGER.debug('existing_split: %s', existing_split)
-    all_current_rows = _to_rows_set(rows)
-    all_existing_rows = _to_rows_set(chain(*existing_split))
+    all_current_rows = _to_row_set(rows)
+    all_existing_rows = _to_row_set(chain(*existing_split))
     not_existing_rows = all_existing_rows - all_current_rows
     if not_existing_rows:
         LOGGER.warning(

--- a/sciencebeam_utils/tools/split_csv_dataset.py
+++ b/sciencebeam_utils/tools/split_csv_dataset.py
@@ -75,11 +75,22 @@ def split_rows(rows, percentages, fill=False, existing_split=None):
         chunk_size_list = get_chunk_size_list(len(rows), percentages, fill=fill)
         return split_row_chunks(rows, chunk_size_list)
     LOGGER.debug('existing_split: %s', existing_split)
+    rows_set = {
+        _to_hashable(row)
+        for row in rows
+    }
     all_existing_rows = {
         _to_hashable(row)
         for existing_rows in existing_split
         for row in existing_rows
     }
+    not_existing_rows = all_existing_rows - rows_set
+    if not_existing_rows:
+        LOGGER.warning(
+            'some rows (%d of %d) from the existing split do not exist'
+            ' in the source list, e.g.: %s',
+            len(not_existing_rows), len(all_existing_rows), list(not_existing_rows)[:3]
+        )
     remaining_rows = [row for row in rows if _to_hashable(row) not in all_existing_rows]
     chunk_size_list = get_chunk_size_list(len(rows), percentages, fill=fill)
     existing_chunk_size_list = [len(existing_rows) for existing_rows in existing_split]

--- a/sciencebeam_utils/tools/split_csv_dataset.py
+++ b/sciencebeam_utils/tools/split_csv_dataset.py
@@ -6,6 +6,7 @@ from math import trunc
 from random import shuffle
 from datetime import datetime
 from itertools import chain
+from typing import List  # pylint: disable=unused-import
 
 from apache_beam.io.filesystems import FileSystems
 
@@ -27,6 +28,9 @@ from sciencebeam_utils.tools.tool_utils import (
 
 
 LOGGER = logging.getLogger(__name__)
+
+
+Row = List[str]
 
 
 def extract_proportions_from_args(args):
@@ -86,7 +90,12 @@ def _substract_list(list1, list2):
     return [a - b for a, b in zip(list1, list2)]
 
 
-def split_rows(rows, percentages, fill=False, existing_split=None):
+def split_rows(
+        rows,  # type: List[Row]
+        percentages,  # type: List[float]
+        fill=False,  # type: bool
+        existing_split=None):  # type: List[List[Row]]
+    # type: (...) -> List[Row]
     if not existing_split:
         return _split_rows_without_existing_split(rows, percentages, fill=fill)
     LOGGER.debug('existing_split: %s', existing_split)

--- a/sciencebeam_utils/tools/split_csv_dataset.py
+++ b/sciencebeam_utils/tools/split_csv_dataset.py
@@ -90,9 +90,13 @@ def split_rows(rows, percentages, fill=False, existing_split=None):
     if not_existing_rows:
         LOGGER.warning(
             'some rows (%d of %d) from the existing split do not exist'
-            ' in the source list, e.g.: %s',
+            ' in the source list and will be removed, e.g.: %s',
             len(not_existing_rows), len(all_existing_rows), list(not_existing_rows)[:3]
         )
+        existing_split = [
+            [row for row in existing_rows if _to_hashable(row) in rows_set]
+            for existing_rows in existing_split
+        ]
     remaining_rows = [row for row in rows if _to_hashable(row) not in all_existing_rows]
     chunk_size_list = get_chunk_size_list(len(rows), percentages, fill=fill)
     existing_chunk_size_list = [len(existing_rows) for existing_rows in existing_split]

--- a/sciencebeam_utils/tools/split_csv_dataset.py
+++ b/sciencebeam_utils/tools/split_csv_dataset.py
@@ -6,7 +6,7 @@ from math import trunc
 from random import shuffle
 from datetime import datetime
 from itertools import chain
-from typing import List  # pylint: disable=unused-import
+from typing import List
 
 from apache_beam.io.filesystems import FileSystems
 

--- a/sciencebeam_utils/tools/split_csv_dataset.py
+++ b/sciencebeam_utils/tools/split_csv_dataset.py
@@ -77,8 +77,8 @@ def split_rows(rows, percentages, fill=False, existing_split=None):
     LOGGER.debug('existing_split: %s', existing_split)
     all_existing_rows = {
         _to_hashable(row)
-        for split_rows in existing_split
-        for row in split_rows
+        for existing_rows in existing_split
+        for row in existing_rows
     }
     remaining_rows = [row for row in rows if _to_hashable(row) not in all_existing_rows]
     chunk_size_list = get_chunk_size_list(len(rows), percentages, fill=fill)

--- a/sciencebeam_utils/tools/split_csv_dataset.py
+++ b/sciencebeam_utils/tools/split_csv_dataset.py
@@ -3,6 +3,7 @@ import csv
 import logging
 from math import trunc
 from random import shuffle
+from datetime import datetime
 
 from apache_beam.io.filesystems import FileSystems
 
@@ -199,6 +200,10 @@ def save_file_sets(output_filenames, delimiter, header_row, data_rows_by_set):
         save_file_set(output_filename, delimiter, header_row, set_data_rows)
 
 
+def get_backup_file_suffix():
+    return '.backup-%s' % datetime.utcnow().strftime(r'%Y%m%d-%H%M%S')
+
+
 def run(args):
     process_args(args)
     ext = get_ext(args.input)
@@ -231,6 +236,15 @@ def run(args):
         fill=args.fill,
         existing_split=existing_file_sets
     )
+
+    if existing_file_sets:
+        backup_suffix = get_backup_file_suffix()
+        save_file_sets(
+            [s + backup_suffix for s in output_filenames],
+            delimiter,
+            header_row,
+            existing_file_sets
+        )
 
     save_file_sets(
         output_filenames,

--- a/sciencebeam_utils/tools/split_csv_dataset.py
+++ b/sciencebeam_utils/tools/split_csv_dataset.py
@@ -225,16 +225,16 @@ def run(args):
     if args.random:
         shuffle(data_rows)
 
-    if args.extend_existing:
+    try:
         existing_file_sets = load_file_sets(output_filenames, delimiter, args.no_header)
-    else:
+    except IOError:
         existing_file_sets = None
 
     data_rows_by_set = split_rows(
         data_rows,
         [p for _, p in proportions],
         fill=args.fill,
-        existing_split=existing_file_sets
+        existing_split=existing_file_sets if args.extend_existing else None
     )
 
     if existing_file_sets:

--- a/sciencebeam_utils/tools/split_csv_dataset.py
+++ b/sciencebeam_utils/tools/split_csv_dataset.py
@@ -143,8 +143,8 @@ def parse_args(argv=None):
         help='use up all of the remaining data rows for the last set'
     )
     parser.add_argument(
-        '--extend-existing', action='store_true', default=False,
-        help='extend and preserve the existing split (new entries will be added)'
+        '--no-extend-existing', action='store_true', default=False,
+        help='do not extend and preserve the existing split (new entries will be addedby default)'
     )
     parser.add_argument(
         '--no-header', action='store_true', default=False,
@@ -241,7 +241,7 @@ def run(args):
         data_rows,
         [p for _, p in proportions],
         fill=args.fill,
-        existing_split=existing_file_sets if args.extend_existing else None
+        existing_split=existing_file_sets if not args.no_extend_existing else None
     )
 
     if existing_file_sets:

--- a/sciencebeam_utils/tools/split_csv_dataset.py
+++ b/sciencebeam_utils/tools/split_csv_dataset.py
@@ -70,7 +70,7 @@ def split_row_chunks(rows, chunk_size_list):
 
 
 def _to_hashable(value):
-    return str(value)
+    return tuple(value) if isinstance(value, list) else value
 
 
 def _to_rows_set(rows):

--- a/sciencebeam_utils/tools/split_csv_dataset.py
+++ b/sciencebeam_utils/tools/split_csv_dataset.py
@@ -83,10 +83,7 @@ def _split_rows_without_existing_split(rows, percentages, fill=False):
 
 
 def _substract_list(list1, list2):
-    return [
-        a - b
-        for a, b in zip(list1, list2)
-    ]
+    return [a - b for a, b in zip(list1, list2)]
 
 
 def split_rows(rows, percentages, fill=False, existing_split=None):

--- a/sciencebeam_utils/tools/split_csv_dataset.py
+++ b/sciencebeam_utils/tools/split_csv_dataset.py
@@ -81,11 +81,16 @@ def split_rows(rows, percentages, fill=False, existing_split=None):
         for row in split_rows
     }
     remaining_rows = [row for row in rows if _to_hashable(row) not in all_existing_rows]
-    chunk_size_list = get_chunk_size_list(len(remaining_rows), percentages, fill=fill)
+    chunk_size_list = get_chunk_size_list(len(rows), percentages, fill=fill)
+    existing_chunk_size_list = [len(existing_rows) for existing_rows in existing_split]
+    remaining_chunk_size_list = [
+        a - b
+        for a, b in zip(chunk_size_list, existing_chunk_size_list)
+    ]
     return [
         existing_rows + new_split
         for existing_rows, new_split in zip(
-            existing_split, split_row_chunks(remaining_rows, chunk_size_list)
+            existing_split, split_row_chunks(remaining_rows, remaining_chunk_size_list)
         )
     ]
 

--- a/sciencebeam_utils/tools/split_csv_dataset.py
+++ b/sciencebeam_utils/tools/split_csv_dataset.py
@@ -95,7 +95,7 @@ def split_rows(
         percentages,  # type: List[float]
         fill=False,  # type: bool
         existing_split=None):  # type: List[List[Row]]
-    # type: (...) -> List[Row]
+    # type: (...) -> List[List[Row]]
     if not existing_split:
         return _split_rows_without_existing_split(rows, percentages, fill=fill)
     LOGGER.debug('existing_split: %s', existing_split)

--- a/sciencebeam_utils/tools/split_csv_dataset.py
+++ b/sciencebeam_utils/tools/split_csv_dataset.py
@@ -74,7 +74,7 @@ def split_row_chunks(rows, chunk_size_list):
 
 
 def _to_hashable(value):
-    return tuple(value) if isinstance(value, list) else value
+    return tuple(value)
 
 
 def _to_rows_set(rows):

--- a/sciencebeam_utils/tools/split_csv_dataset.py
+++ b/sciencebeam_utils/tools/split_csv_dataset.py
@@ -1,6 +1,7 @@
 import argparse
 import csv
 import logging
+import errno
 from math import trunc
 from random import shuffle
 from datetime import datetime
@@ -185,6 +186,15 @@ def load_file_sets(filenames, delimiter, no_header):
     ]
 
 
+def load_file_sets_or_none(filenames, delimiter, no_header):
+    try:
+        return load_file_sets(filenames, delimiter, no_header)
+    except IOError as e:
+        if e.errno == errno.ENOENT:
+            return None
+        raise e
+
+
 def save_file_set(output_filename, delimiter, header_row, set_data_rows):
     mime_type = 'text/tsv' if delimiter == '\t' else 'text/csv'
     with FileSystems.create(output_filename, mime_type=mime_type) as f:
@@ -225,10 +235,7 @@ def run(args):
     if args.random:
         shuffle(data_rows)
 
-    try:
-        existing_file_sets = load_file_sets(output_filenames, delimiter, args.no_header)
-    except IOError:
-        existing_file_sets = None
+    existing_file_sets = load_file_sets_or_none(output_filenames, delimiter, args.no_header)
 
     data_rows_by_set = split_rows(
         data_rows,

--- a/sciencebeam_utils/tools/split_csv_dataset_test.py
+++ b/sciencebeam_utils/tools/split_csv_dataset_test.py
@@ -83,6 +83,13 @@ class TestSplitRows(object):
             existing_split[1] + list(range(8, 10))
         ])
 
+    def test_should_add_new_files_to_existing_uneven_split_train_test(self):
+        existing_split = [list(range(3)), list(range(3, 4))]
+        assert split_rows(list(range(10)), [0.6, 0.4], existing_split=existing_split) == [
+            existing_split[0] + list(range(4, 7)),
+            existing_split[1] + list(range(7, 10))
+        ]
+
 
 class TestGetOutputFilenamesForNames(object):
     def test_should_add_name_and_ext_with_path_sep_if_out_ends_with_slash(self):

--- a/sciencebeam_utils/tools/split_csv_dataset_test.py
+++ b/sciencebeam_utils/tools/split_csv_dataset_test.py
@@ -77,14 +77,14 @@ class TestSplitRows(object):
             list(range(6, 11))
         ]
 
-    def test_should_add_new_files_to_existing_split_train_test(self):
+    def test_should_add_new_items_to_existing_split_train_test(self):
         existing_split = [list(range(3)), list(range(3, 5))]
         assert split_rows(list(range(10)), [0.6, 0.4], existing_split=existing_split) == [
             existing_split[0] + list(range(5, 8)),
             existing_split[1] + list(range(8, 10))
         ]
 
-    def test_should_add_new_files_to_existing_split_train_test_csv_row(self):
+    def test_should_add_new_items_to_existing_split_train_as_test_nested_rows(self):
         existing_split = [list(range(3)), list(range(3, 5))]
         assert split_rows(
             _flat_rows_to_nested_rows(range(10)), [0.6, 0.4],
@@ -96,7 +96,7 @@ class TestSplitRows(object):
             existing_split[1] + list(range(8, 10))
         ])
 
-    def test_should_add_new_files_to_existing_uneven_split_train_test(self):
+    def test_should_add_new_items_to_existing_uneven_split_train_test(self):
         existing_split = [list(range(3)), list(range(3, 4))]
         assert split_rows(list(range(10)), [0.6, 0.4], existing_split=existing_split) == [
             existing_split[0] + list(range(4, 7)),

--- a/sciencebeam_utils/tools/split_csv_dataset_test.py
+++ b/sciencebeam_utils/tools/split_csv_dataset_test.py
@@ -103,6 +103,13 @@ class TestSplitRows(object):
             existing_split[1] + list(range(7, 10))
         ]
 
+    def test_should_remove_items_not_present_in_total_list(self):
+        existing_split = [['1', 'x'], ['2', 'y']]
+        assert split_rows(['1', '2', '3', '4'], [0.5, 0.5], existing_split=existing_split) == [
+            ['1', '3'],
+            ['2', '4']
+        ]
+
 
 class TestGetOutputFilenamesForNames(object):
     def test_should_add_name_and_ext_with_path_sep_if_out_ends_with_slash(self):

--- a/sciencebeam_utils/tools/split_csv_dataset_test.py
+++ b/sciencebeam_utils/tools/split_csv_dataset_test.py
@@ -156,8 +156,7 @@ class TestRun(object):
 
         args = parse_args([
             '--input', str(file_list),
-            '--train', str(0.5),
-            '--extend-existing'
+            '--train', str(0.5)
         ])
         run(args)
 
@@ -182,8 +181,7 @@ class TestRun(object):
 
         args = parse_args([
             '--input', str(file_list),
-            '--train', str(0.5),
-            '--extend-existing'
+            '--train', str(0.5)
         ])
         run(args)
 


### PR DESCRIPTION
This is useful where we split the dataset previously and now have more data available. In that case it makes sense to keep the original split for the data we already had (e.g. we may have already trained a model on the training set and if we shouldn't use data for training that may not be in a test set).

It will also backup the previous lists.