### PR TITLE
do not build docker images again

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,12 +58,12 @@ elifePipeline {
             try {
                 parallel(['Project tests (PY2)': {
                     withCommitStatus({
-                        sh "make IMAGE_TAG=${commit} ci-test-py2"
+                        sh "make IMAGE_TAG=${commit} NO_BUILD=y ci-test-py2"
                     }, 'project-tests/py2', commit)
                 },
                 'Project tests (PY3)': {
                     withCommitStatus({
-                        sh "make IMAGE_TAG=${commit} ci-test-py3"
+                        sh "make IMAGE_TAG=${commit} NO_BUILD=y ci-test-py3"
                     }, 'project-tests/py3', commit)
                 }])
             } finally {
@@ -80,7 +80,7 @@ elifePipeline {
         elifePullRequestOnly { prNumber ->
             stage 'Push package to test.pypi.org', {
                 withPypiCredentials 'staging', 'testpypi', {
-                    sh "make IMAGE_TAG=${commit} COMMIT=${commit} ci-push-testpypi"
+                    sh "make IMAGE_TAG=${commit} COMMIT=${commit} NO_BUILD=y ci-push-testpypi"
                 }
             }
         }
@@ -88,7 +88,7 @@ elifePipeline {
         elifeTagOnly { tag ->
             stage 'Push release', {
                 withPypiCredentials 'prod', 'pypi', {
-                    sh "make IMAGE_TAG=${commit} VERSION=${version} ci-push-pypi"
+                    sh "make IMAGE_TAG=${commit} VERSION=${version} NO_BUILD=y ci-push-pypi"
                 }
             }
         }

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,13 @@ DOCKER_COMPOSE_DEV = docker-compose
 DOCKER_COMPOSE_CI = docker-compose -f docker-compose.yml -f docker-compose.ci.yml
 DOCKER_COMPOSE = $(DOCKER_COMPOSE_DEV)
 
-RUN_PY2 = docker-compose run --rm sciencebeam-utils-py2
-RUN_PY3 = docker-compose run --rm sciencebeam-utils-py3
+RUN_PY2 = $(DOCKER_COMPOSE) run --rm sciencebeam-utils-py2
+RUN_PY3 = $(DOCKER_COMPOSE) run --rm sciencebeam-utils-py3
 PYTEST_ARGS =
 
 COMMIT =
 VERSION =
+NO_BUILD =
 
 
 dev-venv:
@@ -23,15 +24,21 @@ dev-venv:
 
 
 build-all:
-	docker-compose build --parallel
+	if [ "$(NO_BUILD)" != "y" ]; then \
+		$(DOCKER_COMPOSE) build --parallel \
+	fi
 
 
 build-py2:
-	docker-compose build sciencebeam-utils-py2
+	if [ "$(NO_BUILD)" != "y" ]; then \
+		$(DOCKER_COMPOSE) build sciencebeam-utils-py2; \
+	fi
 
 
 build-py3:
-	docker-compose build sciencebeam-utils-py3
+	if [ "$(NO_BUILD)" != "y" ]; then \
+		$(DOCKER_COMPOSE) build sciencebeam-utils-py3; \
+	fi
 
 
 delete-pyc:


### PR DESCRIPTION
The docker images were built again, without the version tag. That prevented the push to pypi from the tag to work.