### PR TITLE
added tqdm utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ DOCKER_COMPOSE_DEV = docker-compose
 DOCKER_COMPOSE_CI = docker-compose -f docker-compose.yml -f docker-compose.ci.yml
 DOCKER_COMPOSE = $(DOCKER_COMPOSE_DEV)
 
+VENV = venv
+PIP = $(VENV)/bin/pip
+PYTHON = $(VENV)/bin/python
+
 RUN_PY2 = $(DOCKER_COMPOSE) run --rm sciencebeam-utils-py2
 RUN_PY3 = $(DOCKER_COMPOSE) run --rm sciencebeam-utils-py3
 PYTEST_ARGS =
@@ -10,17 +14,53 @@ COMMIT =
 VERSION =
 NO_BUILD =
 
+venv-clean:
+	@if [ -d "$(VENV)" ]; then \
+		rm -rf "$(VENV)"; \
+	fi
 
-dev-venv:
-	rm -rf venv || true
 
-	virtualenv -p python3.6 venv
+venv-create:
+	python3 -m venv $(VENV)
 
-	venv/bin/pip install -r requirements.txt
 
-	venv/bin/pip install -r requirements.prereq.txt
+venv-create-py2:
+	virtualenv -p python2.7 $(VENV)
 
-	venv/bin/pip install -r requirements.dev.txt
+
+dev-install:
+	$(PIP) install -r requirements.txt
+	$(PIP) install -r requirements.prereq.txt
+	$(PIP) install -r requirements.dev.txt
+
+
+dev-venv: venv-create dev-install
+
+
+dev-flake8:
+	$(PYTHON) -m flake8 sciencebeam_utils tests setup.py
+
+
+dev-pylint:
+	$(PYTHON) -m pylint sciencebeam_utils tests setup.py
+
+
+dev-lint: dev-flake8 dev-pylint
+
+
+dev-pytest:
+	$(PYTHON) -m pytest -p no:cacheprovider $(ARGS)
+
+
+dev-watch:
+	$(PYTHON) -m pytest_watch --verbose --ext=.py,.xsl -- -p no:cacheprovider -k 'not slow' $(ARGS)
+
+
+dev-watch-slow:
+	$(PYTHON) -m pytest_watch --verbose --ext=.py,.xsl -- -p no:cacheprovider $(ARGS)
+
+
+dev-test: dev-lint dev-pytest
 
 
 build-all:

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -5,14 +5,14 @@ set -e
 # avoid issues with .pyc/pyo files when mounting source directory
 export PYTHONOPTIMIZE=
 
-echo "running tests"
-pytest -p no:cacheprovider
+echo "running flake8"
+flake8 sciencebeam_utils tests
 
 echo "running pylint"
 PYLINTHOME=/tmp/sciencebeam-utils \
   pylint sciencebeam_utils tests
 
-echo "running flake8"
-flake8 sciencebeam_utils tests
+echo "running tests"
+pytest -p no:cacheprovider
 
 echo "done"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-testpaths = sciencebeam_utils
+testpaths = tests
 cache_dir = .temp/pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ backports.csv>=1.0
 lxml>=4.2.0
 numpy>=1.14.2
 six>=1.11.0
+tqdm>=4.0.0

--- a/sciencebeam_utils/utils/tqdm.py
+++ b/sciencebeam_utils/utils/tqdm.py
@@ -19,27 +19,25 @@ class TqdmLoggingHandler(logging.StreamHandler):
             self.handleError(record)
 
 
+def _is_console_logging_handler(handler):
+    return isinstance(handler, logging.StreamHandler) and handler.stream in {sys.stdout, sys.stderr}
+
+
 @contextmanager
 def redirect_logging_to_tqdm(logger=None):
     if logger is None:
         logger = logging.root
     tqdm_handler = TqdmLoggingHandler()
-    console_handlers = [
-        handler
-        for handler in logger.handlers
-        if isinstance(handler, logging.StreamHandler) and handler.stream in {sys.stdout, sys.stderr}
-    ]
-    if console_handlers:
-        tqdm_handler.setFormatter(console_handlers[0].formatter)
+    original_handlers = logger.handlers
     try:
-        logger.addHandler(tqdm_handler)
-        for handler in console_handlers:
-            logger.removeHandler(handler)
+        logger.handlers = [
+            handler
+            for handler in logger.handlers
+            if not _is_console_logging_handler(handler)
+        ] + [tqdm_handler]
         yield
     finally:
-        logger.removeHandler(tqdm_handler)
-        for handler in console_handlers:
-            logger.addHandler(handler)
+        logger.handlers = original_handlers
 
 
 @contextmanager

--- a/sciencebeam_utils/utils/tqdm.py
+++ b/sciencebeam_utils/utils/tqdm.py
@@ -23,12 +23,20 @@ def _is_console_logging_handler(handler):
     return isinstance(handler, logging.StreamHandler) and handler.stream in {sys.stdout, sys.stderr}
 
 
+def _get_console_formatter(handlers):
+    for handler in handlers:
+        if _is_console_logging_handler(handler):
+            return handler.formatter
+    return None
+
+
 @contextmanager
 def redirect_logging_to_tqdm(logger=None):
     if logger is None:
         logger = logging.root
     tqdm_handler = TqdmLoggingHandler()
     original_handlers = logger.handlers
+    tqdm_handler.setFormatter(_get_console_formatter(original_handlers))
     try:
         logger.handlers = [
             handler

--- a/sciencebeam_utils/utils/tqdm.py
+++ b/sciencebeam_utils/utils/tqdm.py
@@ -1,0 +1,48 @@
+import logging
+import sys
+from contextlib import contextmanager
+
+from tqdm import tqdm
+
+
+class TqdmLoggingHandler(logging.StreamHandler):
+    def emit(self, record):
+        try:
+            msg = self.format(record)
+            tqdm.write(msg)
+            self.flush()
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except:  # pylint: disable=bare-except
+            self.handleError(record)
+
+
+@contextmanager
+def redirect_logging_to_tqdm(logger=None):
+    if logger is None:
+        logger = logging.root
+    tqdm_handler = TqdmLoggingHandler()
+    console_handlers = [
+        handler
+        for handler in logger.handlers
+        if isinstance(handler, logging.StreamHandler) and handler.stream in {sys.stdout, sys.stderr}
+    ]
+    if console_handlers:
+        tqdm_handler.setFormatter(console_handlers[0].formatter)
+    try:
+        logger.addHandler(tqdm_handler)
+        for handler in console_handlers:
+            logger.removeHandler(handler)
+        yield
+    finally:
+        logger.removeHandler(tqdm_handler)
+        for handler in console_handlers:
+            logger.addHandler(handler)
+
+
+@contextmanager
+def tqdm_with_logging_redirect(*args, **kwargs):
+    logger = kwargs.pop('logger')
+    with tqdm(*args, **kwargs) as pbar:
+        with redirect_logging_to_tqdm(logger=logger):
+            yield pbar

--- a/sciencebeam_utils/utils/tqdm.py
+++ b/sciencebeam_utils/utils/tqdm.py
@@ -42,7 +42,7 @@ def redirect_logging_to_tqdm(logger=None):
 
 @contextmanager
 def tqdm_with_logging_redirect(*args, **kwargs):
-    logger = kwargs.pop('logger')
+    logger = kwargs.pop('logger', None)
     with tqdm(*args, **kwargs) as pbar:
         with redirect_logging_to_tqdm(logger=logger):
             yield pbar

--- a/sciencebeam_utils/utils/tqdm.py
+++ b/sciencebeam_utils/utils/tqdm.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import logging
 import sys
 from contextlib import contextmanager
@@ -13,7 +15,7 @@ class TqdmLoggingHandler(logging.StreamHandler):
             self.flush()
         except (KeyboardInterrupt, SystemExit):
             raise
-        except:  # pylint: disable=bare-except
+        except:  # noqa pylint: disable=bare-except
             self.handleError(record)
 
 

--- a/tests/utils/tqdm_test.py
+++ b/tests/utils/tqdm_test.py
@@ -68,3 +68,4 @@ class TestTqdmWithLoggingRedirect(object):
             assert isinstance(logger.handlers[0], TqdmLoggingHandler)
             LOGGER.info('test')
             pbar.update(1)
+        assert not logger.handlers

--- a/tests/utils/tqdm_test.py
+++ b/tests/utils/tqdm_test.py
@@ -4,7 +4,14 @@ import logging
 import sys
 from io import StringIO
 
-from sciencebeam_utils.utils.tqdm import redirect_logging_to_tqdm, TqdmLoggingHandler
+from sciencebeam_utils.utils.tqdm import (
+    redirect_logging_to_tqdm,
+    tqdm_with_logging_redirect,
+    TqdmLoggingHandler
+)
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class TestRedirectLoggingToTqdm(object):
@@ -34,3 +41,21 @@ class TestRedirectLoggingToTqdm(object):
             assert logger.handlers[0] == stream_handler
             assert isinstance(logger.handlers[1], TqdmLoggingHandler)
         assert logger.handlers == [stream_handler]
+
+
+class TestTqdmWithLoggingRedirect(object):
+    def test_should_add_and_remove_handler_from_root_logger_by_default(self):
+        original_handlers = list(logging.root.handlers)
+        with tqdm_with_logging_redirect(total=1) as pbar:
+            assert isinstance(logging.root.handlers[-1], TqdmLoggingHandler)
+            LOGGER.info('test')
+            pbar.update(1)
+        assert logging.root.handlers == original_handlers
+
+    def test_should_add_and_remove_handler_from_custom_logger(self):
+        logger = logging.Logger('test')
+        with tqdm_with_logging_redirect(total=1, logger=logger) as pbar:
+            assert len(logger.handlers) == 1
+            assert isinstance(logger.handlers[0], TqdmLoggingHandler)
+            LOGGER.info('test')
+            pbar.update(1)

--- a/tests/utils/tqdm_test.py
+++ b/tests/utils/tqdm_test.py
@@ -32,6 +32,15 @@ class TestRedirectLoggingToTqdm(object):
             assert isinstance(logger.handlers[0], TqdmLoggingHandler)
         assert logger.handlers == [stderr_console_handler, stdout_console_handler]
 
+    def test_should_inherit_console_logger_formatter(self):
+        logger = logging.Logger('test')
+        formatter = logging.Formatter('custom: %(message)')
+        console_handler = logging.StreamHandler(sys.stderr)
+        console_handler.setFormatter(formatter)
+        logger.handlers = [console_handler]
+        with redirect_logging_to_tqdm(logger=logger):
+            assert logger.handlers[0].formatter == formatter
+
     def test_should_not_remove_stream_handlers_not_fot_stdout_or_stderr(self):
         logger = logging.Logger('test')
         stream_handler = logging.StreamHandler(StringIO())

--- a/tests/utils/tqdm_test.py
+++ b/tests/utils/tqdm_test.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import
+
+import logging
+import sys
+from io import StringIO
+
+from sciencebeam_utils.utils.tqdm import redirect_logging_to_tqdm, TqdmLoggingHandler
+
+
+class TestRedirectLoggingToTqdm(object):
+    def test_should_add_and_remove_tqdm_handler(self):
+        logger = logging.Logger('test')
+        with redirect_logging_to_tqdm(logger=logger):
+            assert len(logger.handlers) == 1
+            assert isinstance(logger.handlers[0], TqdmLoggingHandler)
+        assert not logger.handlers
+
+    def test_should_remove_and_restore_console_handlers(self):
+        logger = logging.Logger('test')
+        stderr_console_handler = logging.StreamHandler(sys.stderr)
+        stdout_console_handler = logging.StreamHandler(sys.stderr)
+        logger.handlers = [stderr_console_handler, stdout_console_handler]
+        with redirect_logging_to_tqdm(logger=logger):
+            assert len(logger.handlers) == 1
+            assert isinstance(logger.handlers[0], TqdmLoggingHandler)
+        assert logger.handlers == [stderr_console_handler, stdout_console_handler]
+
+    def test_should_not_remove_stream_handlers_not_fot_stdout_or_stderr(self):
+        logger = logging.Logger('test')
+        stream_handler = logging.StreamHandler(StringIO())
+        logger.addHandler(stream_handler)
+        with redirect_logging_to_tqdm(logger=logger):
+            assert len(logger.handlers) == 2
+            assert logger.handlers[0] == stream_handler
+            assert isinstance(logger.handlers[1], TqdmLoggingHandler)
+        assert logger.handlers == [stream_handler]


### PR DESCRIPTION
added tqdm utils to help with redirecting logging to tqdm.

e.g.
```python
import logging
from sciencebeam_utils.utils.tqdm import tqdm_with_logging_redirect

LOGGER = logging.getLogger(__name__)

if __name__ == '__main__':
    logging.basicConfig(level='INFO')

    file_list = ['file1', 'file2']
    with tqdm_with_logging_redirect(total=len(file_list)) as pbar:
        # logging to the console is now redirected to tqdm
        for filename in file_list:
            LOGGER.info('processing file: %s', filename)
            pbar.update(1)
    # logging is now restored
```