### PR TITLE
fixed get cloud project python 3

### DIFF
--- a/sciencebeam_utils/beam_utils/main.py
+++ b/sciencebeam_utils/beam_utils/main.py
@@ -125,15 +125,12 @@ def process_cloud_args(parsed_args, output_path, name=None):
     if parsed_args.cloud:
         # Flags which need to be set for cloud runs.
         default_values = {
-            'project':
-            get_cloud_project(),
-            'temp_location':
-            os.path.join(os.path.dirname(output_path), 'temp'),
-            'runner':
-            'DataflowRunner',
-            'save_main_session':
-            True,
+            'temp_location':  os.path.join(os.path.dirname(output_path), 'temp'),
+            'runner': 'DataflowRunner',
+            'save_main_session': True,
         }
+        if not parsed_args.project:
+            parsed_args.project = get_cloud_project()
         if not parsed_args.job_name:
             parsed_args.job_name = get_default_job_name(name, parsed_args.job_name_suffix)
     else:

--- a/sciencebeam_utils/beam_utils/main.py
+++ b/sciencebeam_utils/beam_utils/main.py
@@ -4,6 +4,9 @@ import os
 import subprocess
 
 
+from six import text_type
+
+
 def get_logger():
     return logging.getLogger(__name__)
 
@@ -29,6 +32,9 @@ def get_cloud_project():
                     'flag or set a default project: '
                     'gcloud config set project YOUR_PROJECT_NAME'
                 )
+
+            if not isinstance(res, text_type):
+                res = res.decode('utf-8')
             return res
         except OSError as e:
             if e.errno == errno.ENOENT:

--- a/tests/beam_utils/main_test.py
+++ b/tests/beam_utils/main_test.py
@@ -1,3 +1,4 @@
+import argparse
 import subprocess
 from mock import patch
 
@@ -5,15 +6,35 @@ import pytest
 
 from six import text_type, binary_type
 
-from sciencebeam_utils.beam_utils.main import get_cloud_project
+from sciencebeam_utils.utils.collection import extend_dict
+
+import sciencebeam_utils.beam_utils.main as main_module
+from sciencebeam_utils.beam_utils.main import get_cloud_project, process_cloud_args
 
 
 PROJECT_1 = 'project1'
 
 
+DEFAULT_ARGS = dict(
+    project=None,
+    job_name=None,
+    job_name_suffix=None,
+    num_workers=10,
+    cloud=False
+)
+
+DEFAULT_OUTPUT_PATH = '/tmp/output'
+
+
 @pytest.fixture(name='check_output_mock')
 def _check_output_mock():
     with patch.object(subprocess, 'check_output') as mock:
+        yield mock
+
+
+@pytest.fixture(name='get_cloud_project_mock')
+def _get_cloud_project_mock():
+    with patch.object(main_module, 'get_cloud_project') as mock:
         yield mock
 
 
@@ -29,3 +50,33 @@ class TestGetCloudProject(object):
     def test_should_return_text_type_if_check_output_text_type(self, check_output_mock):
         check_output_mock.return_value = text_type(PROJECT_1)
         assert isinstance(get_cloud_project(), text_type)
+
+
+@pytest.mark.usefixtures('get_cloud_project_mock')
+class TestProcessCloudArgs(object):
+    def test_should_use_get_cloud_project_if_project_is_empty(
+            self, get_cloud_project_mock):
+        get_cloud_project_mock.return_value = PROJECT_1
+        args = argparse.Namespace(**extend_dict(DEFAULT_ARGS, {
+            'cloud': True,
+            'project': None
+        }))
+        process_cloud_args(args, output_path=DEFAULT_OUTPUT_PATH)
+        assert args.project == PROJECT_1  # pylint: disable=no-member
+
+    def test_should_not_call_get_cloud_project_if_cloud_is_false(
+            self, get_cloud_project_mock):
+        args = argparse.Namespace(**extend_dict(DEFAULT_ARGS, {
+            'cloud': False
+        }))
+        process_cloud_args(args, output_path=DEFAULT_OUTPUT_PATH)
+        get_cloud_project_mock.assert_not_called()
+
+    def test_should_not_call_get_cloud_project_if_project_was_specified(
+            self, get_cloud_project_mock):
+        args = argparse.Namespace(**extend_dict(DEFAULT_ARGS, {
+            'cloud': True,
+            'project': PROJECT_1
+        }))
+        process_cloud_args(args, output_path=DEFAULT_OUTPUT_PATH)
+        get_cloud_project_mock.assert_not_called()

--- a/tests/beam_utils/main_test.py
+++ b/tests/beam_utils/main_test.py
@@ -1,0 +1,31 @@
+import subprocess
+from mock import patch
+
+import pytest
+
+from six import text_type, binary_type
+
+from sciencebeam_utils.beam_utils.main import get_cloud_project
+
+
+PROJECT_1 = 'project1'
+
+
+@pytest.fixture(name='check_output_mock')
+def _check_output_mock():
+    with patch.object(subprocess, 'check_output') as mock:
+        yield mock
+
+
+class TestGetCloudProject(object):
+    def test_should_return_project(self, check_output_mock):
+        check_output_mock.return_value = PROJECT_1
+        assert get_cloud_project() == PROJECT_1
+
+    def test_should_return_text_type_if_check_output_returns_bytes(self, check_output_mock):
+        check_output_mock.return_value = binary_type(PROJECT_1)
+        assert isinstance(get_cloud_project(), text_type)
+
+    def test_should_return_text_type_if_check_output_text_type(self, check_output_mock):
+        check_output_mock.return_value = text_type(PROJECT_1)
+        assert isinstance(get_cloud_project(), text_type)

--- a/tests/beam_utils/main_test.py
+++ b/tests/beam_utils/main_test.py
@@ -4,7 +4,7 @@ from mock import patch
 
 import pytest
 
-from six import text_type, binary_type
+from six import text_type
 
 from sciencebeam_utils.utils.collection import extend_dict
 
@@ -44,7 +44,7 @@ class TestGetCloudProject(object):
         assert get_cloud_project() == PROJECT_1
 
     def test_should_return_text_type_if_check_output_returns_bytes(self, check_output_mock):
-        check_output_mock.return_value = binary_type(PROJECT_1)
+        check_output_mock.return_value = PROJECT_1.encode('utf-8')
         assert isinstance(get_cloud_project(), text_type)
 
     def test_should_return_text_type_if_check_output_text_type(self, check_output_mock):


### PR DESCRIPTION
Using Python 3, `get_cloud_project` returned `bytes`, which wasn't accepted by Apache Beam as a valid project name.

This also no longer calls `get_cloud_project` if a project was specified.