### PR TITLE
fixed tqdm logging in progress_logger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN pip install -r requirements.dev.txt
 
 COPY sciencebeam_utils ${PROJECT_HOME}/sciencebeam_utils
 COPY tests ${PROJECT_HOME}/tests
-COPY README.md *.conf *.sh *.in *.txt *.py .pylintrc .flake8 ${PROJECT_HOME}/
+COPY README.md *.conf *.sh *.in *.txt *.py .pylintrc .flake8 pytest.ini ${PROJECT_HOME}/
 
 ARG version
 ADD docker ./docker

--- a/sciencebeam_utils/utils/progress_logger.py
+++ b/sciencebeam_utils/utils/progress_logger.py
@@ -3,7 +3,7 @@ import logging
 from tqdm import tqdm
 
 
-LOGGER = logging.getLogger()
+LOGGER = logging.getLogger(__name__)
 
 
 class logging_tqdm(tqdm):
@@ -35,5 +35,5 @@ class logging_tqdm(tqdm):
             # skip progress bar before having processed anything
             return
         if not msg:
-            msg = self.__repr__()
+            msg = self.__str__()
         self.logger.info('%s', msg)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,6 @@ import pytest
 
 @pytest.fixture(scope='session', autouse=True)
 def setup_logging():
-    logging.root.handlers = []
     logging.basicConfig(level='INFO')
-    logging.getLogger('sciencebeam_utils').setLevel('DEBUG')
+    for name in ['tests', 'sciencebeam_utils']:
+        logging.getLogger(name).setLevel('DEBUG')

--- a/tests/utils/progress_logger_test.py
+++ b/tests/utils/progress_logger_test.py
@@ -1,0 +1,17 @@
+import logging
+from io import StringIO
+
+from sciencebeam_utils.utils.progress_logger import logging_tqdm
+
+
+class TestLoggingTqdm:
+    def test_should_log_tqdm_output(self):
+        logger = logging.Logger('test')
+        out = StringIO()
+        stream_handler = logging.StreamHandler(out)
+        logger.addHandler(stream_handler)
+        with logging_tqdm(total=2, logger=logger, mininterval=0) as pbar:
+            pbar.update(1)
+        last_log_line = out.getvalue().splitlines()[-1]
+        assert '50%' in last_log_line
+        assert '1/2' in last_log_line

--- a/tests/utils/tqdm_test.py
+++ b/tests/utils/tqdm_test.py
@@ -34,7 +34,7 @@ class TestRedirectLoggingToTqdm:
 
     def test_should_inherit_console_logger_formatter(self):
         logger = logging.Logger('test')
-        formatter = logging.Formatter('custom: %(message)')
+        formatter = logging.Formatter('custom: %(message)s')
         console_handler = logging.StreamHandler(sys.stderr)
         console_handler.setFormatter(formatter)
         logger.handlers = [console_handler]


### PR DESCRIPTION
`tqdm` seem to have changed, and it is now necessary to call `__str__` instead of `__repr__`.